### PR TITLE
updated limit for filecoin container on space00 node, done it to reflect new size of the node

### DIFF
--- a/values/prod/spacerace/space00.yaml
+++ b/values/prod/spacerace/space00.yaml
@@ -48,8 +48,8 @@ resources:
       cpu: 23
       memory: 160Gi
     limits:
-      cpu: 29
-      memory: 220Gi
+      cpu: 40
+      memory: 294Gi
   ipfs:
     requests:
       cpu: 2


### PR DESCRIPTION
OOM killer has killed filecoin container again, we've enlarged the size of the node, but forgot to update container limits.