### PR TITLE
updated to 1.15.0 version and returned space06 and api-read to start from local blockchain, store only 3 last revisions for helm

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.5.0-pre3
-appVersion: v1.13.2
+appVersion: v1.15.0

--- a/Makefile
+++ b/Makefile
@@ -8,16 +8,16 @@ NAMESPACE = calibrationnet
 ## lotus nodes management
 
 nodeInstall:
-	helm upgrade --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
+	helm upgrade --history-max 3 --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
 
 nodeReinit:
 	helm -n $(NAMESPACE) delete $(NODE)
-	helm upgrade --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
+	helm upgrade --history-max 3 --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
 
 nodeReinstall:
 	helm -n $(NAMESPACE) delete $(NODE)
 	kubectl -n $(NAMESPACE) delete pvc vol-lotus-$(NODE)-lotus-0
-	helm upgrade --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
+	helm upgrade --history-max 3 --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .
 
 diff:
 	helm diff upgrade --install -f values-$(NAMESPACE).yaml -f values/$(ENV)/$(NAMESPACE)/$(NODE).yaml $(NODE) -n $(NAMESPACE) .

--- a/values-calibrationnet.yaml
+++ b/values-calibrationnet.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: glif/lotus:v1.14.0-rc7-calibnet
+  repository: glif/lotus:v1.15.0-calibnet
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/values-spacerace.yaml
+++ b/values-spacerace.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: glif/lotus:v1.13.2
+  repository: glif/lotus:v1.15.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/values/dev/spacerace/api-read-dev.yaml
+++ b/values/dev/spacerace/api-read-dev.yaml
@@ -3,7 +3,7 @@ cache:
   replicas: 1
 
 image:
-  repository: glif/lotus:v1.13.2
+  repository: glif/lotus:v1.15.0
 
 init:
   importSnapshot:

--- a/values/prod/spacerace/api-read.yaml
+++ b/values/prod/spacerace/api-read.yaml
@@ -8,8 +8,8 @@ init:
  importSnapshot:
    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
    enabled: true
- clearRestart:
-   enabled: true
+#  clearRestart:
+#    enabled: true
 
 ingress:
   lotus:

--- a/values/prod/spacerace/space06.yaml
+++ b/values/prod/spacerace/space06.yaml
@@ -1,14 +1,14 @@
 cache:
   enabled: true
 
-init:
-  importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
-    IPFS_GW: "https://node.glif.io/space00/ipfs/8080/ipfs"
-    SNAPSHOT_CID: "https://gist.githubusercontent.com/openworklabbot/d03393d1f6e70e089e9e8d18922474f6/raw/snapshot.log"
-    enabled: true
-  clearRestart:
-    enabled: true
+# init:
+#   importSnapshot:
+#     SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+#     IPFS_GW: "https://node.glif.io/space00/ipfs/8080/ipfs"
+#     SNAPSHOT_CID: "https://gist.githubusercontent.com/openworklabbot/d03393d1f6e70e089e9e8d18922474f6/raw/snapshot.log"
+#     enabled: true
+#   clearRestart:
+#     enabled: true
 
 Lotus:
   service:


### PR DESCRIPTION
what was done:
* updated to 1.15.0 version
* returned space06 and api-read to start from local blockchain
* helm history is limited to the 3 last revisions