### PR TITLE
[feat] - update lily to 0.10.1 which support v16 Skyr update, change …

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,4 +16,4 @@ maintainers:
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 # appVersion: 1.5.0-pre3
-appVersion: v0.8.8
+appVersion: v0.10.1

--- a/templates/cj-lily-gapfill.yaml
+++ b/templates/cj-lily-gapfill.yaml
@@ -119,7 +119,7 @@ spec:
             - name: LILY_CONFIG
               value: "/var/lib/lily/config.toml"
             {{- range .Values.daemon.storage.postgresql }}
-            - name: LILY_STORAGE_POSTGRESQL_{{ .name | upper }}_URL
+            - name: LILY_{{ .name | upper }}
               valueFrom:
                 secretKeyRef:
                   name: {{ required "expected secret name which holds postgres connection url" .secretName }}

--- a/templates/cm-lily-daemon.yaml
+++ b/templates/cm-lily-daemon.yaml
@@ -26,7 +26,7 @@ data:
         {{- range .Values.daemon.storage.postgresql }}
         [Storage.Postgresql.{{ .name }}]
           SchemaName = {{ .schema | default "lily" | quote }}
-          URLEnv = "LILY_STORAGE_POSTGRESQL_{{ .name | upper }}_URL"
+          URLEnv = "LILY_{{ .name | upper }}"
           ApplicationName = {{ .applicationName | default (include "chart.name" $ ) | quote }}
           PoolSize = {{ .poolSize | default 20 }}
           AllowUpsert = {{ .allowUpsert | default false }}

--- a/templates/sts.yaml
+++ b/templates/sts.yaml
@@ -315,7 +315,7 @@ spec:
             - name: LILY_CONFIG
               value: "/var/lib/lily/config.toml"
             {{- range .Values.daemon.storage.postgresql }}
-            - name: LILY_STORAGE_POSTGRESQL_{{ .name | upper }}_URL
+            - name: LILY_{{ .name | upper }}
               valueFrom:
                 secretKeyRef:
                   name: {{ required "expected secret name which holds postgres connection url" .secretName }}
@@ -367,7 +367,7 @@ spec:
                     {{- else }}
                         {{- $jobName = printf "--name %s/%s" .jobId .command }}
                     {{- end }}
-                    lily sync wait && lily {{ .command }} {{ join " " .args }} {{ $jobName }}
+                    lily sync wait && lily migrate --latest && lily {{ .command }} {{ $jobName }} {{ join " " .args }}
                     {{- end }}
           {{- end }}
           resources:

--- a/values-calib10-lily.yaml
+++ b/values-calib10-lily.yaml
@@ -4,7 +4,7 @@ client: "lily"
 image:
   repo: filecoin/lily
   pullPolicy: IfNotPresent
-  tag: v0.8.8-calibnet
+  tag: v0.10.1-calibnet
 
 releaseGroup: lilymain-group
 
@@ -35,13 +35,13 @@ daemon:
       allowUpsert: false
     file: []
   jobs:
-    - command: watch
+    - command: job run
       name: "calib10-watch-job"
       jobId: "123456"
       args:
-        - --confidence=30
         - --tasks=blocks,messages,chaineconomics,msapprovals,actorstatesraw,actorstatesmultisig,actorstatesinit
-        - --storage=db
+        - watch
+        - --confidence=30
   genesisUnix: "1624060800"
   gapfill:
     enabled: false

--- a/values-lily00-spacerace.yaml
+++ b/values-lily00-spacerace.yaml
@@ -6,7 +6,7 @@ client: "lily"
 image:
   repo: filecoin/lily
   pullPolicy: IfNotPresent
-  tag: v0.8.8
+  tag: v0.10.1
 
 releaseGroup: lilymain-group
 
@@ -42,21 +42,21 @@ daemon:
       allowUpsert: false
     file: []
   jobs:
-    - command: watch
+    - command: job run
       name: "space-watch-job"
       jobId: "346928"
       args:
-        - --confidence=60
         - --tasks=blocks,messages,chaineconomics,msapprovals,actorstatesraw,actorstatesmultisig,actorstatesinit
-        - --storage=db
-    - command: walk
-      name: "space-walk-job"
-      jobId: "235987"
-      args:
-        - --storage=db
-        - --tasks=actorstatesinit
-        - --from=1682157
-        - --to=1718110
+        - watch
+        - --confidence=60
+    # - command: walk
+    #   name: "space-walk-job"
+    #   jobId: "235987"
+    #   args:
+    #     - --storage=db
+    #     - --tasks=actorstatesinit
+    #     - --from=1682157
+    #     - --to=1718110
   genesisUnix: "1598306400"
   gapfill:
     enabled: false


### PR DESCRIPTION
What was done:
* update lily to 0.10.1 which support v16 Skyr update;
* change LILY_STORAGE_POSTGRESQL_DB_URL to LILY_DB as env var
* *change the order of arguments for watch job