### PR TITLE
[feat] - add bigger timeout for space06 lotus service

### DIFF
--- a/templates/service-lotus.yaml
+++ b/templates/service-lotus.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     app: lotus-node-app
   annotations:
+  # Annotation to apply timeout from https://github.com/glifio/filecoin-iac/blob/main/k8s/kong_ingress_timeout.tf
+  {{- if .Values.Lotus.service.kongConfig }}
+    konghq.com/override: {{ .Values.Lotus.service.kongConfig }}
+  {{- end}}
     prometheus.io/scrape: "true"
     prometheus.io/port: "1234"
     prometheus.io/path: /debug/metrics

--- a/templates/service-lotus.yaml
+++ b/templates/service-lotus.yaml
@@ -5,14 +5,17 @@ metadata:
   name: {{ .Release.Name }}-lotus-service
   labels:
     app: lotus-node-app
+  {{- if .Values.Lotus.service.annotations.default }}
   annotations:
-  # Annotation to apply timeout from https://github.com/glifio/filecoin-iac/blob/main/k8s/kong_ingress_timeout.tf
-  {{- if .Values.Lotus.service.kongConfig }}
-    konghq.com/override: {{ .Values.Lotus.service.kongConfig }}
-  {{- end}}
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "1234"
-    prometheus.io/path: /debug/metrics
+  {{- range $key, $value := .Values.Lotus.service.annotations.default }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.Lotus.service.annotations.custom }}
+  {{- range $key, $value := .Values.Lotus.service.annotations.custom }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/values.yaml
+++ b/values.yaml
@@ -9,11 +9,6 @@ nodeSelector:
   nodeSelectorKey: nodeGroupName
   nodeSelectorValue: noGroup
 
-
-lotus:
-  service:
-    enabled: true
-
 image:
   repository: glif/lotus:v1.16.0-calibnet
   pullPolicy: Always
@@ -140,7 +135,15 @@ Lotus:
     is_slave: false
     label: some-release
     gateway: false
-
+    annotations:
+      # default annotations are used for every lotus service
+      default:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "1234"
+        prometheus.io/path: /debug/metrics
+      # custom annotations on service used if u need to something non-trivial, e.x. set custom timeout on the service
+      custom:
+        {}
 # Defines remote endpoint for services(StateDiff e.t.c.)
 #lotusDNS: some-service
 

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -14,7 +14,15 @@ init:
 Lotus:
   service:
     gateway: true
-    kongConfig: kong-ingress-read-timeout
+    annotations:
+      custom:
+        # We add annotation below, because faced with long operation, which has taken around 2 minutes to complete on
+        #   the Lotus side.
+        # Due to this we found that it could be configured in the Kong ingress configuration and used by annotation on
+        #   the desired service.
+        # Ingress configuration placed here:
+        #   https://github.com/glifio/filecoin-iac/blob/main/k8s/kong_ingress_timeout.tf
+        konghq.com/override: kong-ingress-read-timeout
 
 image:
   repository: glif/lotus:v1.16.0

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -14,6 +14,7 @@ init:
 Lotus:
   service:
     gateway: true
+    kongConfig: kong-ingress-read-timeout
 
 image:
   repository: glif/lotus:v1.16.0


### PR DESCRIPTION
Super trivial change:
if variable exist -> put new annotation for timeout.
---
Refactor:
1. moved service annotations to the separate dictionary value.
2. added default value
3. rewrite value for space06 with new timeout
4. refactor Lotus and lotus variables to only `lotus`

Tested for refactoring - nothing really changed, only order:
```
uladzislau@MURAVEIKANB:~/repos/filecoin-chart$ for i in $(ls -1 values/mainnet/network/ | grep -v cache | cut -d. -f 1); do make diff NODE="$i";done
helm diff upgrade --install -f values.yaml -f values/mainnet/network/api-read-master.yaml api-read-master -n network .
network, api-read-master-lotus-service, Service (v1) has changed:
  # Source: filecoin/templates/service-lotus.yaml
    annotations:
-     prometheus.io/scrape: "true"
+     prometheus.io/path: "/debug/metrics"
      prometheus.io/port: "1234"
-     prometheus.io/path: /debug/metrics
+     prometheus.io/scrape: "true"
helm diff upgrade --install -f values.yaml -f values/mainnet/network/api-read-slave-0.yaml api-read-slave-0 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/api-read-slave-1.yaml api-read-slave-1 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/api-read-slave-2.yaml api-read-slave-2 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space00.yaml space00 -n network .
network, space00-lotus-service, Service (v1) has changed:
  # Source: filecoin/templates/service-lotus.yaml
    annotations:
-     prometheus.io/scrape: "true"
+     prometheus.io/path: "/debug/metrics"
      prometheus.io/port: "1234"
-     prometheus.io/path: /debug/metrics
+     prometheus.io/scrape: "true"
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space06-1.yaml space06-1 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space06.yaml space06 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space07.yaml space07 -n network .
network, space07-lotus-service, Service (v1) has changed:
  # Source: filecoin/templates/service-lotus.yaml
    annotations:
-     prometheus.io/scrape: "true"
+     prometheus.io/path: "/debug/metrics"
      prometheus.io/port: "1234"
-     prometheus.io/path: /debug/metrics
+     prometheus.io/scrape: "true"
```