### PR TITLE
[Fix]Changed version image to v1.18.0-rc5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ all: lint package
 #  NAMESPACE = network
 
 ## Deploy archive_node
-NODE = wallaby-archive
-ENV = dev
-NAMESPACE = network
+# NODE = wallaby-archive
+# ENV = dev
+# NAMESPACE = network
 
 ### Deploy api_read_node
 #NODE = api-read-dev
@@ -22,10 +22,10 @@ NAMESPACE = network
 #ENV = dev
 #NAMESPACE = network
 
-## Deploy calibnetapi
-#NODE = calibrationapi
-#ENV = dev
-#NAMESPACE = network
+# Deploy calibnetapi
+NODE = wallaby-archive
+ENV = dev
+NAMESPACE = network
 
 ## Deploy calibnetapi-jwt
 #NODE = calibrationapi-jwt

--- a/values.yaml
+++ b/values.yaml
@@ -10,7 +10,7 @@ nodeSelector:
   nodeSelectorValue: noGroup
 
 image:
-  repository: glif/lotus:1.18.0-rc3-calibnet
+  repository: glif/lotus:1.18.0-rc5-calibnet
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/values/dev/network/calibrationapi-archive-node.yaml
+++ b/values/dev/network/calibrationapi-archive-node.yaml
@@ -12,6 +12,8 @@ Lotus:
   env:
     custom:
       LOTUS_VM_ENABLE_TRACING: "true"
+    # default:
+    #   INFRA_CLEAR_RESTART: "true"
 
 persistence:
 #  autoResizer:

--- a/values/dev/network/calibrationapi.yaml
+++ b/values/dev/network/calibrationapi.yaml
@@ -11,12 +11,12 @@ IPFS:
 
 init:
   importSnapshot:
-    # SNAPSHOTURL: "http://calibrationapi-ipfs-service:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
-    # SNAPSHOTURL: "http://localhost:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
-    # SNAPSHOTURL: "/data/ipfs/lotus-current.car"
-    SNAPSHOTURL: "https://snapshots.calibrationnet.filops.net/minimal/latest"
+  #   # SNAPSHOTURL: "http://calibrationapi-ipfs-service:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
+  #   # SNAPSHOTURL: "http://localhost:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
+  #   # SNAPSHOTURL: "/data/ipfs/lotus-current.car"
+  #   SNAPSHOTURL: "https://snapshots.calibrationnet.filops.net/minimal/latest"
 
-    enabled: true
+    enabled: false
 
 Lotus:
   service:


### PR DESCRIPTION
Signed-off-by: lazavikmaria <lazavikmaria@gmail.com>

What was done:

1. Was changed version image to v1.18.0-rc5.
2. Was disabled flag "importSnapshot" for calibrationapi ==> Didn't restore by snapshot, because was reset pvc.
3. Was enabled flag  (INFRA_CLEAR_RESTART: "true")  for calibrationapi-archive-node ==> cleaned  old data, because version  blockchain  has changed n16->n17. 
     After recreated container ( this flag was committed).