### PR TITLE
[FIX]Fix oom nodes. 

### DIFF
--- a/templates/deployment-cache.yaml
+++ b/templates/deployment-cache.yaml
@@ -39,5 +39,8 @@ spec:
           - key: config
             path: config.yaml
       nodeSelector:
-        {{ .Values.nodeSelector.nodeSelectorKey }}: {{ .Values.nodeSelector.nodeSelectorValue }}
+        {{- $mergedNodeSelector := merge .Values.nodeSelector.custom .Values.nodeSelector.default -}}
+        {{ range $key, $value := $mergedNodeSelector }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -209,6 +209,7 @@ spec:
 
       nodeSelector:
         {{ .Values.nodeSelector.nodeSelectorKey }}: {{ .Values.nodeSelector.nodeSelectorValue }}
+        {{ .Values.nodeSelector.nodeSelectorAllow }}: {{ .Values.nodeSelector.nodeSelectorLabel }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
 {{- if .Values.Lotus.enabled }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -208,8 +208,10 @@ spec:
 {{- end }}
 
       nodeSelector:
-        {{ .Values.nodeSelector.nodeSelectorKey }}: {{ .Values.nodeSelector.nodeSelectorValue }}
-        {{ .Values.nodeSelector.nodeSelectorAllow }}: {{ .Values.nodeSelector.nodeSelectorLabel }}
+      {{- $mergedNodeSelector := merge .Values.nodeSelector.custom .Values.nodeSelector.default -}}
+      {{ range $key, $value := $mergedNodeSelector }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
 {{- if .Values.Lotus.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,12 +6,8 @@ replicaCount: 1
 
 nodeSelector:
   enabled: true
-  default:
-   nodeSelectorKey: nodeGroupName
-   nodeSelectorValue: noGroup
-  custom:
-   nodeSelectorAllow: assign_pods_to_key_nodes
-   nodeSelectorLabel: podLabel
+  default: {}
+  custom: {}
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values.yaml
+++ b/values.yaml
@@ -6,10 +6,12 @@ replicaCount: 1
 
 nodeSelector:
   enabled: true
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: noGroup
-  nodeSelectorAllow: assign_pods_to_key_nodes
-  nodeSelectorLabel: podLabel
+  default:
+   nodeSelectorKey: nodeGroupName
+   nodeSelectorValue: noGroup
+  custom:
+   nodeSelectorAllow: assign_pods_to_key_nodes
+   nodeSelectorLabel: podLabel
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,11 @@ nodeSelector:
   enabled: true
   nodeSelectorKey: nodeGroupName
   nodeSelectorValue: noGroup
+  nodeSelectorAllow: assign_pods_to_key_nodes
+  nodeSelectorLabel: podLabel
+  ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
+  ## another option, by default pods assign by any nodes "allow_any_pods".
+
 
 image:
   repository: glif/lotus:1.18.0-rc5-calibnet

--- a/values/dev/network/api-read-cache-dev.yaml
+++ b/values/dev/network/api-read-cache-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+   nodeGroupName: group2
 
 #self-managed cache-service integration
 cache:

--- a/values/dev/network/api-read-dev.yaml
+++ b/values/dev/network/api-read-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+    nodeGroupName: group2
 
 init:
   importSnapshot:

--- a/values/dev/network/calibrationapi-archive-node.yaml
+++ b/values/dev/network/calibrationapi-archive-node.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group4
+  default:
+    nodeGroupName: group4
 
 IPFS:
   enabled: false

--- a/values/dev/network/calibrationapi-archive.yaml
+++ b/values/dev/network/calibrationapi-archive.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group4
+  default:
+   nodeGroupName: group4
 
 IPFS:
   enabled: false

--- a/values/dev/network/calibrationapi-jwt.yaml
+++ b/values/dev/network/calibrationapi-jwt.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group1
+  default:
+    nodeGroupName: group1
 
 #ingress:
 #  ipfs:

--- a/values/dev/network/calibrationapi.yaml
+++ b/values/dev/network/calibrationapi.yaml
@@ -1,6 +1,12 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group3
+  default:
+   nodeSelectorKey: nodeGroupName
+   nodeSelectorValue: group3
+  custom:
+   nodeSelectorAllow: assign_pods_to_key_nodes
+   nodeSelectorLabel: allow_any_pods
+
+
 
 IPFS:
   enabled: true

--- a/values/dev/network/calibrationapi.yaml
+++ b/values/dev/network/calibrationapi.yaml
@@ -1,12 +1,8 @@
 nodeSelector:
   default:
-   nodeSelectorKey: nodeGroupName
-   nodeSelectorValue: group3
+    nodeGroupName: group3
   custom:
-   nodeSelectorAllow: assign_pods_to_key_nodes
-   nodeSelectorLabel: allow_any_pods
-
-
+    assign_pods_to_key_nodes: allow_any_pods
 
 IPFS:
   enabled: true

--- a/values/dev/network/calibrationapi.yaml
+++ b/values/dev/network/calibrationapi.yaml
@@ -1,8 +1,6 @@
 nodeSelector:
   default:
     nodeGroupName: group3
-  custom:
-    assign_pods_to_key_nodes: allow_any_pods
 
 IPFS:
   enabled: true

--- a/values/dev/network/wallaby-archive-slave.yaml
+++ b/values/dev/network/wallaby-archive-slave.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group3
+  default:
+    nodeGroupName: group3
 
 image:
   repository: glif/lotus:wallaby_latest

--- a/values/dev/network/wallaby-archive.yaml
+++ b/values/dev/network/wallaby-archive.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group3
+  default:
+    nodeGroupName: group3
 
 image:
   repository: glif/lotus:wallaby_latest

--- a/values/mainnet/network/api-read-master.yaml
+++ b/values/mainnet/network/api-read-master.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group6
+  default:
+   nodeGroupName: group6
 
 Lotus:
   env:

--- a/values/mainnet/network/api-read-slave-0.yaml
+++ b/values/mainnet/network/api-read-slave-0.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+   nodeGroupName: group2
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-1.yaml
+++ b/values/mainnet/network/api-read-slave-1.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group8
+  default:
+   nodeGroupName: group8
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-2.yaml
+++ b/values/mainnet/network/api-read-slave-2.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group9
+  default:
+   nodeGroupName: group9
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-3.yaml
+++ b/values/mainnet/network/api-read-slave-3.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group7
+  default:
+   nodeGroupName: group7
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-v0-cache.yaml
+++ b/values/mainnet/network/api-read-v0-cache.yaml
@@ -2,7 +2,7 @@ nodeSelector:
   default:
     lifecycle: ondemand
   custom:
-    assign_pods_to_key_nodes: allow_any_pods
+    assign_to_space00_07_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/api-read-v0-cache.yaml
+++ b/values/mainnet/network/api-read-v0-cache.yaml
@@ -1,8 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
-  nodeSelectorAllow: assign_pods_to_key_nodes
-  nodeSelectorLabel: allow_any_pods
+  default:
+    lifecycle: ondemand
+  custom:
+    assign_pods_to_key_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/api-read-v0-cache.yaml
+++ b/values/mainnet/network/api-read-v0-cache.yaml
@@ -1,6 +1,10 @@
 nodeSelector:
   nodeSelectorKey: lifecycle
   nodeSelectorValue: ondemand
+  nodeSelectorAllow: assign_pods_to_key_nodes
+  nodeSelectorLabel: allow_any_pods
+  ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
+  ## another option, by default pods assign by any nodes "allow_any_pods".
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/api-read-v1-cache.yaml
+++ b/values/mainnet/network/api-read-v1-cache.yaml
@@ -1,8 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
-  nodeSelectorAllow: assign_pods_to_key_nodes
-  nodeSelectorLabel: allow_any_pods
+  default:
+   lifecycle: ondemand
+  custom:
+   assign_pods_to_key_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/api-read-v1-cache.yaml
+++ b/values/mainnet/network/api-read-v1-cache.yaml
@@ -2,7 +2,7 @@ nodeSelector:
   default:
    lifecycle: ondemand
   custom:
-   assign_pods_to_key_nodes: allow_any_pods
+    assign_to_space00_07_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/api-read-v1-cache.yaml
+++ b/values/mainnet/network/api-read-v1-cache.yaml
@@ -1,6 +1,10 @@
 nodeSelector:
   nodeSelectorKey: lifecycle
   nodeSelectorValue: ondemand
+  nodeSelectorAllow: assign_pods_to_key_nodes
+  nodeSelectorLabel: allow_any_pods
+  ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
+  ## another option, by default pods assign by any nodes "allow_any_pods".
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/space00.yaml
+++ b/values/mainnet/network/space00.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group5
+  default:
+   nodeGroupName: group5
 
 IPFS:
   enabled: true

--- a/values/mainnet/network/space06-1.yaml
+++ b/values/mainnet/network/space06-1.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group10
+  default:
+   nodeGroupName: group10
 
 init:
   importSnapshot:

--- a/values/mainnet/network/space06-cache.yaml
+++ b/values/mainnet/network/space06-cache.yaml
@@ -1,8 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
-  nodeSelectorAllow: assign_pods_to_key_nodes
-  nodeSelectorLabel: allow_any_pods
+  default:
+   lifecycle: ondemand
+  custom:
+   assign_pods_to_key_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/space06-cache.yaml
+++ b/values/mainnet/network/space06-cache.yaml
@@ -2,7 +2,7 @@ nodeSelector:
   default:
    lifecycle: ondemand
   custom:
-   assign_pods_to_key_nodes: allow_any_pods
+    assign_to_space00_07_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/space06-cache.yaml
+++ b/values/mainnet/network/space06-cache.yaml
@@ -1,6 +1,10 @@
 nodeSelector:
   nodeSelectorKey: lifecycle
   nodeSelectorValue: ondemand
+  nodeSelectorAllow: assign_pods_to_key_nodes
+  nodeSelectorLabel: allow_any_pods
+  ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
+  ## another option, by default pods assign by any nodes "allow_any_pods".
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group3
+  default:
+   nodeGroupName: group3
 
 
 

--- a/values/mainnet/network/space07-cache.yaml
+++ b/values/mainnet/network/space07-cache.yaml
@@ -1,8 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
-  nodeSelectorAllow: assign_pods_to_key_nodes
-  nodeSelectorLabel: allow_any_pods
+  default:
+   lifecycle: ondemand
+  custom:
+   assign_pods_to_key_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/space07-cache.yaml
+++ b/values/mainnet/network/space07-cache.yaml
@@ -2,7 +2,7 @@ nodeSelector:
   default:
    lifecycle: ondemand
   custom:
-   assign_pods_to_key_nodes: allow_any_pods
+    assign_to_space00_07_nodes: allow_any_pods
   ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
   ## another option, by default pods assign by any nodes "allow_any_pods".
 

--- a/values/mainnet/network/space07-cache.yaml
+++ b/values/mainnet/network/space07-cache.yaml
@@ -1,6 +1,10 @@
 nodeSelector:
   nodeSelectorKey: lifecycle
   nodeSelectorValue: ondemand
+  nodeSelectorAllow: assign_pods_to_key_nodes
+  nodeSelectorLabel: allow_any_pods
+  ## If we need assign critical pods by only node "space00" use nodeSelectorLabel "allow_only_critical_pods",
+  ## another option, by default pods assign by any nodes "allow_any_pods".
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/space07.yaml
+++ b/values/mainnet/network/space07.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group4
+  default:
+   nodeGroupName: group4
 
 Lotus:
   service:


### PR DESCRIPTION
Was created variable in filecoin-iac  "assign_pods_to_key_nodes" ==> All instances have label
assign_pods_to_key_nodes = allow_any_pods by default value (false).
If we need that only critical pods assign to only critical nodes ( nodegroup 5, nodegroup 7 == space00, space07) switch on value (true) == >
assign_pods_to_key_nodes = allow_only_critical_pods.

!!! IMPORTANT !!!
After apply all instances dev + mainnet will restart.

 In helm charts was created nodeSelectors for pods  to allow any nodes besides group5, group7 ( space00,space07) :
- api-read-v0-cache
- api-read-v1-cache
- space06-cache
- space07-cache

