### PR TITLE
Changed nodeSelector.

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -208,7 +208,10 @@ spec:
 {{- end }}
 
       nodeSelector:
-        {{ .Values.nodeSelector.nodeSelectorKey }}: {{ .Values.nodeSelector.nodeSelectorValue }}
+     {{- $mergedNodeSelector := merge .Values.nodeSelector.custom .Values.nodeSelector.default -}}
+     {{ range $key, $value := $mergedNodeSelector }}
+       {{ $key }}: {{ $value | quote }}
+     {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
 {{- if .Values.Lotus.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 
 nodeSelector:
   enabled: true
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: noGroup
+  default: {}
+  custom: {}
 
 image:
   repository: glif/lotus:1.18.0-rc5-calibnet

--- a/values/dev/network/api-read-cache-dev.yaml
+++ b/values/dev/network/api-read-cache-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
   default:
-   nodeGroupName: group2
+    nodeGroupName: group2
 
 #self-managed cache-service integration
 cache:

--- a/values/dev/network/api-read-cache-dev.yaml
+++ b/values/dev/network/api-read-cache-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+   nodeGroupName: group2
 
 #self-managed cache-service integration
 cache:

--- a/values/dev/network/api-read-dev.yaml
+++ b/values/dev/network/api-read-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+  nodeGroupName: group2
 
 init:
   importSnapshot:

--- a/values/dev/network/api-read-dev.yaml
+++ b/values/dev/network/api-read-dev.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
   default:
-  nodeGroupName: group2
+    nodeGroupName: group2
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-master.yaml
+++ b/values/mainnet/network/api-read-master.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group6
+  default:
+    nodeGroupName: group6
 
 Lotus:
   env:

--- a/values/mainnet/network/api-read-slave-0.yaml
+++ b/values/mainnet/network/api-read-slave-0.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group2
+  default:
+    nodeGroupName: group2
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-1.yaml
+++ b/values/mainnet/network/api-read-slave-1.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group8
+  default:
+    nodeGroupName: group6
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-2.yaml
+++ b/values/mainnet/network/api-read-slave-2.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group9
+  default:
+    nodeGroupName: group9
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-slave-3.yaml
+++ b/values/mainnet/network/api-read-slave-3.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group7
+  default:
+    nodeGroupName: group7
 
 init:
   importSnapshot:

--- a/values/mainnet/network/api-read-v0-cache.yaml
+++ b/values/mainnet/network/api-read-v0-cache.yaml
@@ -1,6 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
+  default:
+    lifecycle: ondemand
+  custom:
+    assign_to_space00_07_nodes: allow_any_pods
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/api-read-v1-cache.yaml
+++ b/values/mainnet/network/api-read-v1-cache.yaml
@@ -1,6 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
+  default:
+    lifecycle: ondemand
+  custom:
+    assign_to_space00_07_nodes: allow_any_pods
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/calibrationapi-archive-node.yaml
+++ b/values/mainnet/network/calibrationapi-archive-node.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group12
+  default:
+    nodeGroupName: group12
 
 IPFS:
   enabled: false

--- a/values/mainnet/network/calibrationapi.yaml
+++ b/values/mainnet/network/calibrationapi.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group11
+  default:
+    nodeGroupName: group11
 
 IPFS:
   enabled: true

--- a/values/mainnet/network/space00.yaml
+++ b/values/mainnet/network/space00.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group5
+  default:
+    nodeGroupName: group5
 
 IPFS:
   enabled: true

--- a/values/mainnet/network/space06-1.yaml
+++ b/values/mainnet/network/space06-1.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group10
+  default:
+    nodeGroupName: group10
 
 init:
   importSnapshot:

--- a/values/mainnet/network/space06-cache.yaml
+++ b/values/mainnet/network/space06-cache.yaml
@@ -1,6 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
+  default:
+    lifecycle: ondemand
+  custom:
+    assign_to_space00_07_nodes: allow_any_pods
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group3
+  default:
+    nodeGroupName: group3
 
 
 

--- a/values/mainnet/network/space07-cache.yaml
+++ b/values/mainnet/network/space07-cache.yaml
@@ -1,6 +1,8 @@
 nodeSelector:
-  nodeSelectorKey: lifecycle
-  nodeSelectorValue: ondemand
+  default:
+    lifecycle: ondemand
+  custom:
+    assign_to_space00_07_nodes: allow_any_pods
 
 #self-managed cache-service integration
 cache:

--- a/values/mainnet/network/space07.yaml
+++ b/values/mainnet/network/space07.yaml
@@ -1,6 +1,6 @@
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group4
+  default:
+    nodeGroupName: group4
 
 Lotus:
   service:

--- a/values/mainnet/network/wallaby-archive-slave-1.yaml
+++ b/values/mainnet/network/wallaby-archive-slave-1.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group12
+  default:
+    nodeGroupName: group12
 
 image:
   repository: glif/lotus:wallaby_latest

--- a/values/mainnet/network/wallaby-archive-slave.yaml
+++ b/values/mainnet/network/wallaby-archive-slave.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group11
+  default:
+    nodeGroupName: group11
 
 image:
   repository: glif/lotus:wallaby_latest

--- a/values/mainnet/network/wallaby-archive.yaml
+++ b/values/mainnet/network/wallaby-archive.yaml
@@ -1,7 +1,7 @@
 # you have to put the group name from existing EKS working group names.
 nodeSelector:
-  nodeSelectorKey: nodeGroupName
-  nodeSelectorValue: group11
+  default:
+    nodeGroupName: group11
 
 image:
   repository: glif/lotus:wallaby_latest


### PR DESCRIPTION
Was created variable "assign_pods_to_key_nodes" ==> All instances have label  
assign_pods_to_key_nodes = allow_any_pods by default value (false).  
If we need that only critical pods assign to only critical nodes ( nodegroup 5, nodegroup 7 == space00, space07) switch on value (true) == >  
assign_pods_to_key_nodes = allow_only_critical_pods.
!!! IMPORTANT !!!  
After apply all instances dev + mainnet will

Rewrote approach to nodeSelectors templates 