### PR TITLE
Updated to 1.18.0 version.

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -210,7 +210,7 @@ spec:
       nodeSelector:
      {{- $mergedNodeSelector := merge .Values.nodeSelector.custom .Values.nodeSelector.default -}}
      {{ range $key, $value := $mergedNodeSelector }}
-       {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ $value | quote }}
      {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/values.yaml
+++ b/values.yaml
@@ -10,7 +10,7 @@ nodeSelector:
   custom: {}
 
 image:
-  repository: glif/lotus:1.18.0-rc5-calibnet
+  repository: glif/lotus:1.18.0-calibnet
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/values/dev/network/api-read-dev.yaml
+++ b/values/dev/network/api-read-dev.yaml
@@ -4,13 +4,13 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
     enabled: true
   clearRestart:
     enabled: true
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 Lotus:
   service:

--- a/values/mainnet/network/api-read-master.yaml
+++ b/values/mainnet/network/api-read-master.yaml
@@ -9,11 +9,11 @@ Lotus:
       INFRA_LOTUS_GATEWAY: "true"
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
     enabled: true
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 resources:
   lotus:

--- a/values/mainnet/network/api-read-slave-0.yaml
+++ b/values/mainnet/network/api-read-slave-0.yaml
@@ -4,7 +4,7 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
     enabled: true
 
 Lotus:
@@ -18,7 +18,7 @@ Lotus:
       INFRA_LOTUS_GATEWAY: "true"
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 resources:
   lotus:

--- a/values/mainnet/network/api-read-slave-1.yaml
+++ b/values/mainnet/network/api-read-slave-1.yaml
@@ -1,16 +1,16 @@
 nodeSelector:
   default:
-    nodeGroupName: group6
+    nodeGroupName: group8
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.ca"
     enabled: true
   clearRestart:
     enabled: true
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 Lotus:
   service:

--- a/values/mainnet/network/api-read-slave-1.yaml
+++ b/values/mainnet/network/api-read-slave-1.yaml
@@ -4,7 +4,7 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.ca"
+    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
     enabled: true
   clearRestart:
     enabled: true

--- a/values/mainnet/network/api-read-slave-2.yaml
+++ b/values/mainnet/network/api-read-slave-2.yaml
@@ -13,7 +13,7 @@ init:
       LOTUS_VM_ENABLE_TRACING: "true"
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 Lotus:
   service:

--- a/values/mainnet/network/api-read-slave-3.yaml
+++ b/values/mainnet/network/api-read-slave-3.yaml
@@ -4,7 +4,7 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
     enabled: true
 
 Lotus:
@@ -18,7 +18,7 @@ Lotus:
       INFRA_LOTUS_GATEWAY: "true"
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 resources:
   lotus:

--- a/values/mainnet/network/calibrationapi.yaml
+++ b/values/mainnet/network/calibrationapi.yaml
@@ -14,8 +14,7 @@ init:
   #   # SNAPSHOTURL: "http://calibrationapi-ipfs-service:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
   #   # SNAPSHOTURL: "http://localhost:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
   #   # SNAPSHOTURL: "/data/ipfs/lotus-current.car"
-  #   SNAPSHOTURL: "https://snapshots.calibrationnet.filops.net/minimal/latest"
-
+    SNAPSHOTURL: "https://snapshots.calibrationnet.filops.net/minimal/latest"
     enabled: false
 
 Lotus:
@@ -23,7 +22,7 @@ Lotus:
     release: calibrationapi
   env:
     default:
-      INFRA_CLEAR_RESTART: "true"
+      INFRA_CLEAR_RESTART: "false"
     custom:
       INFRA_LOTUS_GATEWAY: "true"
       LOTUS_MAX_HEAP: "10GiB"

--- a/values/mainnet/network/space00.yaml
+++ b/values/mainnet/network/space00.yaml
@@ -23,7 +23,7 @@ Lotus:
         konghq.com/override: kong-ingress-one-day-read-timeout
 
 image:
-  repository: glif/lotus:v1.16.0-bootstrap
+  repository: glif/lotus:v1.18.0-bootstrap
 
 persistence:
   autoResizer:
@@ -53,7 +53,7 @@ persistence:
     storageClassName: "ebs-sc-io2"
     lotusVolumeName: "vol-lotus-io2"
   ipfs:
-    size: "313Gi"
+    size: "250Gi"
 
 resources:
   lotus:

--- a/values/mainnet/network/space06-1.yaml
+++ b/values/mainnet/network/space06-1.yaml
@@ -4,7 +4,7 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
     enabled: true
   clearRestart:
     enabled: true
@@ -23,7 +23,7 @@ Lotus:
 nameOverride: ""
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 persistence:
   enabled: false

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -6,7 +6,7 @@ nodeSelector:
 
 init:
    importSnapshot:
-     SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+     SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
      enabled: true
    clearRestart:
      enabled: false
@@ -29,7 +29,7 @@ Lotus:
         konghq.com/override: kong-ingress-read-timeout
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 nameOverride: ""
 

--- a/values/mainnet/network/space07.yaml
+++ b/values/mainnet/network/space07.yaml
@@ -32,7 +32,7 @@ persistence:
     lotusVolumeName: "vol-lotus-io2"
 
 image:
-  repository: glif/lotus:v1.16.0
+  repository: glif/lotus:v1.18.0
 
 resources:
   lotus:


### PR DESCRIPTION
Updated version image to 1.18.0 of calibrationapi, calibationapi-archive, api-read-master, api-read-slave-0-3, space00, space06-06.01, space07 without wallaby it use image glif/lotus:wallaby_latest. 
Switched on snapshot URL "https://snapshots.mainnet.filops.net/minimal/latest" besides ari-read-slave-1, api-read-slave-2