### PR TITLE
[feat] - add new zst containers download and unpack

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -58,12 +58,43 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command: ["/bin/sh","-c"]
         args:
-          - mkdir -p /tmp/lotus /tmp/ipfs && chown -R 2000:2000 /tmp;
+          - mkdir -p /tmp/lotus /tmp/ipfs /tmp/snapshot && chown -R 2000:2000 /tmp;
         securityContext:
           runAsUser: 0
         volumeMounts:
           - name: {{ .Values.persistence.lotus.lotusVolumeName }}
             mountPath: /tmp
+      - name: download-zst-snapshot
+        image: alpine:3.17
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        workingDir: /home/lotus_user/snapshot
+        command:
+          - "/bin/sh"
+          - "-c"
+        args:
+          - RESTART={{ .Values.Lotus.env.default.INFRA_CLEAR_RESTART }};
+            if [ $RESTART = false ] && [ "$(ls -A /home/lotus_user/.lotus)" ]; then
+              echo "nothing to do here, lotus already have ledger";
+              exit 0;
+            fi;
+            echo "Downloading zst snapshot";
+            apk --no-cache add aria2=1.36.0-r1 zstd=1.5.2-r9 &&
+            aria2c --allow-overwrite --max-connection-per-server 5 --split 5
+              {{ .Values.init.importSnapshot.REMOTE_SNAPSHOT_URL }} -o latest.zst &&
+            pzstd -v --processes "$(nproc)" --force --rm --decompress latest.zst -o latest.car;
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+          - name: {{ .Values.persistence.lotus.lotusVolumeName }}
+            mountPath: /home/lotus_user/snapshot
+          {{- if and (not .Values.persistence.enabled) .Values.persistence.hostPath }}
+            subPath: snapshot
+          {{- end }}
+          - name: {{ .Values.persistence.lotus.lotusVolumeName }}
+            mountPath: /home/lotus_user/.lotus
+            {{- if and (not .Values.persistence.enabled) .Values.persistence.hostPath }}
+            subPath: lotus
+      {{- end }}
 {{- end }}
 {{- end }}
       containers:
@@ -191,6 +222,9 @@ spec:
             mountPath: /home/lotus_user/.lotus
             {{- if and (not .Values.persistence.enabled) .Values.persistence.hostPath }}
             subPath: lotus
+          - name: {{ .Values.persistence.lotus.lotusVolumeName }}
+            mountPath: /home/lotus_user/snapshot
+            subPath: snapshot
             {{- end }}
             {{- if and (.Values.init.import.volume) (.Values.init.import.enabled) }}
           - name: {{ (index .Values.init.import.volume 0).name }}

--- a/values/dev/network/api-read-dev.yaml
+++ b/values/dev/network/api-read-dev.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
   clearRestart:
     enabled: true

--- a/values/mainnet/network/api-read-master.yaml
+++ b/values/mainnet/network/api-read-master.yaml
@@ -9,7 +9,8 @@ Lotus:
       INFRA_LOTUS_GATEWAY: "true"
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
 
 image:

--- a/values/mainnet/network/api-read-slave-0.yaml
+++ b/values/mainnet/network/api-read-slave-0.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
 
 Lotus:

--- a/values/mainnet/network/api-read-slave-1.yaml
+++ b/values/mainnet/network/api-read-slave-1.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
   clearRestart:
     enabled: true

--- a/values/mainnet/network/api-read-slave-2.yaml
+++ b/values/mainnet/network/api-read-slave-2.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://fil-chain-snapshots-fallback.s3.amazonaws.com/mainnet/minimal_finality_stateroots_latest.car"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
   env:
     default:

--- a/values/mainnet/network/api-read-slave-3.yaml
+++ b/values/mainnet/network/api-read-slave-3.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
 
 Lotus:

--- a/values/mainnet/network/calibrationapi.yaml
+++ b/values/mainnet/network/calibrationapi.yaml
@@ -14,7 +14,8 @@ init:
   #   # SNAPSHOTURL: "http://calibrationapi-ipfs-service:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
   #   # SNAPSHOTURL: "http://localhost:8080/ipfs/QmP5yHB5WyszguauePoPCFHCNA8oAqJMgTaESi96ntzZvb"
   #   # SNAPSHOTURL: "/data/ipfs/lotus-current.car"
-    SNAPSHOTURL: "https://snapshots.calibrationnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: false
 
 Lotus:

--- a/values/mainnet/network/space06-1.yaml
+++ b/values/mainnet/network/space06-1.yaml
@@ -4,7 +4,8 @@ nodeSelector:
 
 init:
   importSnapshot:
-    SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
     enabled: true
   clearRestart:
     enabled: true

--- a/values/mainnet/network/space06.yaml
+++ b/values/mainnet/network/space06.yaml
@@ -6,8 +6,9 @@ nodeSelector:
 
 init:
    importSnapshot:
-     SNAPSHOTURL: "https://snapshots.mainnet.filops.net/minimal/latest"
-     enabled: true
+    SNAPSHOTURL: "/home/lotus_user/snapshot/latest.car"
+    REMOTE_SNAPSHOT_URL: "https://snapshots.mainnet.filops.net/minimal/latest.zst"
+    enabled: true
    clearRestart:
      enabled: false
 


### PR DESCRIPTION
Main idea start to use new zst snapshots as soon as possible due to bigger size of snapshots and connection problems with direct access from the lotus.

What was done:
1. New snapshot download is implemented as init-container for the pods which are using NVME disks.
2. Create new folder `snapshot` as part of 1st init container  - `hostpath-permission`
3. Mount `snapshot` folder to the `download-zst-snapshot` as 2nd init container
4. Download in 5 streams, unpack in CPU count parallel, delete initial snapshot.
5. Mount `snapshot` and `lotus` folder as `subPath`es to the main container
5. Point lotus to the local folder `snapshot`

Additionally, I've added checks for the CLEAR_RESTART and covered/tested 3 cases:
* CLEAR_RESTART is `true` - we will download and unpack archive
* CLEAR_RESTART is `false` and lotus folder is non-empty  - we will skip download archive part and `exit 0` 
* CLEAR_RESTART is `false`, **but lotus folder is empty** - consider to download + unpack archive, two edge cases, but we need to cover this:
  *  NVME instance stopped and started - such disks are ephemeral and wouldn't survive stop and start
  * u've updated nodes template and recreating instance, but you have CLEAR_RESTART is false - yeah,

Additionally, I've checked that only api-read-like instances will be affected:
* Instances below doesn't produce any output connected with new approach.
```
helm diff upgrade --install -f values.yaml -f values/mainnet/network/calibrationapi-archive-node.yaml calibrationapi-archive-node -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/calibrationapi.yaml calibrationapi -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space00.yaml space00 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/space00.yaml space07 -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/wallaby-archive.yaml wallaby-archive -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/wallaby-archive-slave.yaml wallaby-archive-slave -n network .
helm diff upgrade --install -f values.yaml -f values/mainnet/network/wallaby-archive-slave-1.yaml wallaby-archive-slave-1 -n network .
```

Further fun, I'll create user stories for this:
* start to delete  humongous 100GB+ archive as part of Dockerfile
* make calibrationapi node to be like api-read
