### PR TITLE
[fix] - Bump zstd version to 1.5.5-r0

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -85,7 +85,7 @@ spec:
             fi;
             rm -rf /home/lotus_user/.lotus/* && rm -rf /home/lotus_user/snapshot/*;
             echo "Downloading zst snapshot";
-            apk --no-cache add aria2=1.36.0-r1 zstd=1.5.2-r9 &&
+            apk --no-cache add aria2=1.36.0-r1 zstd=1.5.5-r0 &&
             aria2c --allow-overwrite --max-connection-per-server 5 --split 5
               {{ .Values.downloadSnapshotUrl }} -o latest.zst &&
             pzstd -v --processes "$(nproc)" --force --rm --decompress latest.zst -o latest.car;


### PR DESCRIPTION
Init containers were failing due to the version constraints