### PR TITLE
[fix] - Fix timeouts, etc.

### DIFF
--- a/templates/service-canary.yaml
+++ b/templates/service-canary.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-canary-lotus-service
   labels:
-    app: lotus-node-app
+    app: lotus-node-canary
   annotations:
   {{- range $key, $value := .Values.canaryServiceAnnotations }}
       {{ $key }}: {{ $value | quote }}

--- a/templates/service-mirrored.yaml
+++ b/templates/service-mirrored.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-mirrored-lotus-service
   labels:
-    app: lotus-node-app
+    app: lotus-node-mirror
   annotations:
   {{- range $key, $value := .Values.mirroredServiceAnnotations }}
       {{ $key }}: {{ $value | quote }}

--- a/values/mainnet/network/api-read-master.yaml
+++ b/values/mainnet/network/api-read-master.yaml
@@ -4,6 +4,7 @@ nodeSelector:
 
 lotusServiceAnnotations:
   konghq.com/override: filecoin-mainnet-apn1-glif-eks-kong-sticky-sessions
+  konghq.com/read-timeout: "600000"
 
 lotusEnv:
   LOTUS_VM_ENABLE_TRACING: "true"
@@ -31,6 +32,7 @@ mirroredServiceSelectors:
   release: api-read-master
 mirroredServiceAnnotations:
   konghq.com/override: filecoin-mainnet-apn1-glif-eks-kong-sticky-sessions
+  konghq.com/read-timeout: 600000
 
 createCanaryService: true
 canaryServiceSelectors:
@@ -38,3 +40,4 @@ canaryServiceSelectors:
   release: "api-read-master"
 canaryServiceAnnotations:
   konghq.com/override: filecoin-mainnet-apn1-glif-eks-kong-sticky-sessions
+  konghq.com/read-timeout: 600000

--- a/values/mainnet/network/api-read-mirror-2.yaml
+++ b/values/mainnet/network/api-read-mirror-2.yaml
@@ -2,9 +2,6 @@ nodeSelector:
   nodeGroupName: group35
   assign_to_space00_07_nodes: allow_any_pods
 
-lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-10m
-
 lotusEnv:
   LOTUS_VM_ENABLE_TRACING: "true"
   INFRA_LOTUS_GATEWAY: "true"

--- a/values/mainnet/network/api-read-mirror.yaml
+++ b/values/mainnet/network/api-read-mirror.yaml
@@ -3,7 +3,7 @@ nodeSelector:
   assign_to_space00_07_nodes: allow_any_pods
 
 lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-10m
+  konghq.com/read-timeout: 600000
 
 lotusEnv:
   LOTUS_VM_ENABLE_TRACING: "true"

--- a/values/mainnet/network/hyperspace-mirror.yaml
+++ b/values/mainnet/network/hyperspace-mirror.yaml
@@ -6,7 +6,7 @@ nodeSelector:
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-amd-custom
 
 lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
+  konghq.com/read-timeout: 1800000
 
 lotusEnv:
   INFRA_CLEAR_RESTART: "false"

--- a/values/mainnet/network/hyperspace-private-0.yaml
+++ b/values/mainnet/network/hyperspace-private-0.yaml
@@ -6,7 +6,7 @@ nodeSelector:
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-arm
 
 lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
+  konghq.com/read-timeout: 1800000
 
 lotusEnv:
   INFRA_CLEAR_RESTART: "false"

--- a/values/mainnet/network/hyperspace-slave-0.yaml
+++ b/values/mainnet/network/hyperspace-slave-0.yaml
@@ -5,9 +5,6 @@ nodeSelector:
 
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-arm-custom
 
-lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
-
 isSlaveNode: true
 createLotusService: false
 customReleaseName: hyperspace

--- a/values/mainnet/network/hyperspace-slave-1.yaml
+++ b/values/mainnet/network/hyperspace-slave-1.yaml
@@ -5,9 +5,6 @@ nodeSelector:
 
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-arm-custom
 
-lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
-
 isSlaveNode: true
 createLotusService: false
 customReleaseName: hyperspace

--- a/values/mainnet/network/hyperspace-slave-2.yaml
+++ b/values/mainnet/network/hyperspace-slave-2.yaml
@@ -5,9 +5,6 @@ nodeSelector:
 
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-arm-custom
 
-lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
-
 isSlaveNode: true
 createLotusService: false
 customReleaseName: hyperspace

--- a/values/mainnet/network/hyperspace.yaml
+++ b/values/mainnet/network/hyperspace.yaml
@@ -6,7 +6,7 @@ nodeSelector:
 lotusImageRepository: glif/lotus:1.20.3-hyperspace-arm-custom
 
 lotusServiceAnnotations:
-  konghq.com/override: kong-ingress-timeout-30m
+  konghq.com/read-timeout: "1800000"
 
 lotusEnv:
   INFRA_CLEAR_RESTART: "false"
@@ -28,3 +28,6 @@ createServiceRoleBinding: false
 createMirroredService: true
 mirroredServiceSelectors:
   statefulset.kubernetes.io/pod-name: hyperspace-lotus-0
+
+importSnapshot: true
+snapshotLocation: https://snapshots.hyperspace.yoga/hyperspace-latest-pruned.car


### PR DESCRIPTION
After the kong upgrade to 3.0.2, setting timeouts via KongIngress became deprecated. Switched to using annotations instead.

Also:
- Disabled metrics scraping for the mirrored and the canary services.
- Enabled import from the snapshot on hyperspace master.