### PR TITLE
[feat] - Make api-read-slave-10 a canary node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all: lint package
 #NAMESPACE = network
 
 # Deploy calibrationapi-archive-node
-NODE = api-read-slave-12
+NODE = api-read-slave-10
 ENV = mainnet
 NAMESPACE = network
 

--- a/values/mainnet/network/api-read-slave-10.yaml
+++ b/values/mainnet/network/api-read-slave-10.yaml
@@ -15,7 +15,7 @@ lotusEnv:
   INFRA_LOTUS_GATEWAY: "true"
   INFRA_CLEAR_RESTART: "false"
 
-lotusImageRepository: glif/lotus:v1.23.0-custom-mainnet-arm64
+lotusImageRepository: glif/lotus:1.23.0-brave-perf-p1-custom-mainnet-arm64-canary
 
 lotusRequestsCpu: 10
 lotusRequestsMemory: 60Gi
@@ -25,3 +25,6 @@ lotusMemoryLimit: 120Gi
 
 isSpotInstance: true
 createServiceRoleBinding: false
+
+customPodLabels:
+  isCanary: "yes"


### PR DESCRIPTION
Needed so the PL team can get a direct access to the canary node through a direct URL, in particular to get Go's pprof.